### PR TITLE
Add: 全てのitemとidでのitem取得を追加

### DIFF
--- a/controllers/item_controller.go
+++ b/controllers/item_controller.go
@@ -1,0 +1,50 @@
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/Yuta-Matsumoto999/go_gin_tutorial/services"
+)
+
+type IItemController interface {
+	FindAll(ctx *gin.Context)
+	FindById(ctx *gin.Context)
+}
+
+type ItemController struct {
+	service services.IItemService
+}
+
+func NewItemController(service services.IItemService) IItemController {
+	return &ItemController{
+		service: service,
+	}
+}
+
+func (c *ItemController) FindAll(ctx *gin.Context) {
+	items, err := c.service.FindAll()
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{"data": items})
+}
+
+func (c *ItemController) FindById(ctx *gin.Context) {
+	itemId, err := strconv.ParseUint(ctx.Param("id"), 10, 64)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid item ID"})
+		return
+	}
+	item, err := c.service.FindById(itemId)
+	if err != nil {
+		if errors.Is(err, errors.New("item not found")) {
+			ctx.JSON(http.StatusNotFound, gin.H{"error": "Item not found"})
+			return
+		}
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Unexpected error"})
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{"data": item})
+}

--- a/controllers/item_controller.go
+++ b/controllers/item_controller.go
@@ -2,9 +2,11 @@ package controllers
 
 import (
 	"net/http"
+	"strconv"
 
-	"github.com/gin-gonic/gin"
+	"github.com/Yuta-Matsumoto999/go_gin_tutorial/repositories"
 	"github.com/Yuta-Matsumoto999/go_gin_tutorial/services"
+	"github.com/gin-gonic/gin"
 )
 
 type IItemController interface {
@@ -32,19 +34,20 @@ func (c *ItemController) FindAll(ctx *gin.Context) {
 }
 
 func (c *ItemController) FindById(ctx *gin.Context) {
-	itemId, err := strconv.ParseUint(ctx.Param("id"), 10, 64)
+	itemIdUint64, err := strconv.ParseUint(ctx.Param("id"), 10, 64)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid item ID"})
 		return
 	}
-	item, err := c.service.FindById(itemId)
+	item, err := c.service.FindById(uint(itemIdUint64))
 	if err != nil {
-		if errors.Is(err, errors.New("item not found")) {
+		if err == repositories.ErrItemNotFound {
 			ctx.JSON(http.StatusNotFound, gin.H{"error": "Item not found"})
 			return
+		} else {
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Unexpected error"})
+			return
 		}
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Unexpected error"})
-		return
 	}
 	ctx.JSON(http.StatusOK, gin.H{"data": item})
 }

--- a/main.go
+++ b/main.go
@@ -1,11 +1,26 @@
 package main
 
-import "github.com/gin-gonic/gin"
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/Yuta-Matsumoto999/go_gin_tutorial/services"
+	"github.com/Yuta-Matsumoto999/go_gin_tutorial/controllers"
+	"github.com/Yuta-Matsumoto999/go_gin_tutorial/models"
+	"github.com/Yuta-Matsumoto999/go_gin_tutorial/repositories"
+)
 
 func main() {
+	items := []models.Item{
+		{ID: 1, Name: "Item 1", Price: 100, Description: "Description 1", SoldOut: false},
+		{ID: 2, Name: "Item 2", Price: 200, Description: "Description 2", SoldOut: true},
+		{ID: 3, Name: "Item 3", Price: 300, Description: "Description 3", SoldOut: false},
+	}
+
+	itemRepository := repositories.NewItemMemoryRepository(items)
+	itemService := services.NewItemService(itemRepository)
+	itemController := controllers.NewItemController(itemService)
+
 	router := gin.Default()
-	router.GET("/sample", func(c *gin.Context) {
-		c.JSON(200, gin.H{"message": "Hello, World!"})
-	})
+	router.GET("/items", itemController.FindAll)
+	router.GET("/items/:id", itemController.FindById)
 	router.Run(":8080")
 }

--- a/models/item.go
+++ b/models/item.go
@@ -1,0 +1,9 @@
+package models
+
+type Item struct {
+	ID          uint   `json:"id"`
+	Name        string `json:"name"`
+	Price       uint   `json:"price"`
+	Description string `json:"description"`
+	SoldOut     bool   `json:"sold_out"`
+}

--- a/repositories/item_repository.go
+++ b/repositories/item_repository.go
@@ -1,0 +1,36 @@
+package repositories
+
+import (
+	"errors"
+	"github.com/Yuta-Matsumoto999/go_gin_tutorial/models"
+)
+
+var ErrItemNotFound = errors.New("item not found")
+
+type IItemRepository interface {
+	FindAll() (*[]models.Item, error)
+	FindById(id uint) (*models.Item, error)
+}
+
+type ItemMemoryRepository struct {
+	items []models.Item
+}
+
+func NewItemMemoryRepository(items []models.Item) IItemRepository {
+	return &ItemMemoryRepository{
+		items: items,
+	}
+}
+
+func (r *ItemMemoryRepository) FindAll() (*[]models.Item, error) {
+	return &r.items, nil
+}
+
+func (r *ItemMemoryRepository) FindById(itemId uint) (*models.Item, error) {
+	for _, item := range r.items {
+		if item.ID == itemId {
+			return &item, nil
+		}
+	}
+	return nil, ErrItemNotFound
+}

--- a/services/item_service.go
+++ b/services/item_service.go
@@ -1,0 +1,29 @@
+package services
+
+import (
+	"github.com/Yuta-Matsumoto999/go_gin_tutorial/models"
+	"github.com/Yuta-Matsumoto999/go_gin_tutorial/repositories"
+)
+
+type IItemService interface {
+	FindAll() (*[]models.Item, error)
+	FindById(itemId uint) (*models.Item, error)
+}
+
+type ItemService struct {
+	repository repositories.IItemRepository
+}
+
+func NewItemService(repository repositories.IItemRepository) IItemService {
+	return &ItemService{
+		repository: repository,
+	}
+}
+
+func (s *ItemService) FindAll() (*[]models.Item, error) {
+	return s.repository.FindAll()
+}
+
+func (s *ItemService) FindById(itemId uint) (*models.Item, error) {
+	return s.repository.FindById(itemId)
+}


### PR DESCRIPTION
# 内容

- エンドポイントの追加
  - `/items`: 全てのitemを取得
  - `/items/:id`: idでitemを個別取得

# 備考

- turtorialのため、itemsデータはハードコードしている。
- 後にDBで永続化する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * すべてのアイテム一覧取得およびID指定による単一アイテム取得のREST APIエンドポイントを追加。
  * アイテムのID、名前、価格、説明、売り切れ状態などの詳細情報を含むレスポンスを提供。
  * 不正なリクエストやアイテム未発見時に適切なHTTPステータスコードと明確なエラーメッセージを返す。

* **Refactor**
  * 以前のサンプルエンドポイントを廃止し、構造化されたアイテム管理用APIに置き換え。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->